### PR TITLE
Fix get_auth_method()

### DIFF
--- a/lib/teachers_pet/actions/base.rb
+++ b/lib/teachers_pet/actions/base.rb
@@ -7,6 +7,8 @@ module TeachersPet
   module Actions
     class Base
       def get_auth_method
+        auth_method = nil
+
         choose do |menu|
           menu.prompt = "Login via oAuth or Password? "
           menu.choice :oAuth do


### PR DESCRIPTION
Fixes https://github.com/education/teachers-pet/issues/19.  Variable scope problem.

![run away](http://31.media.tumblr.com/tumblr_m5wil1Bx9u1qbaj4uo1_500.jpg)

Not sure how to test that method without crazy stubbing :confused: so will probably just hold off for https://github.com/education/teachers-pet/issues/8.
