### PR TITLE
Support password/token prompt

### DIFF
--- a/lib/teachers_pet/actions/base.rb
+++ b/lib/teachers_pet/actions/base.rb
@@ -22,18 +22,18 @@ module TeachersPet
         }
 
         if self.options[:token]
-          if self.options[:token].length > 0
-            opts[:access_token] = self.options[:token]
-          else
+          if self.options[:token].eql?('token')
             print 'Please enter your GitHub token: '
             opts[:access_token] = STDIN.noecho(&:gets).chomp
+          else
+            opts[:access_token] = self.options[:token]
           end
         elsif self.options[:password]
-          if self.options[:password].length > 0
-            opts[:password] = self.options[:password]
-          else
+          if self.options[:password].eql?('password')
             print 'Please enter your GitHub password: '
             opts[:password] = STDIN.noecho(&:gets).chomp
+          else
+            opts[:password] = self.options[:password]
           end
         else
           raise Thor::RequiredArgumentMissingError.new("No value provided for option --password or --token")

--- a/spec/actions/base_spec.rb
+++ b/spec/actions/base_spec.rb
@@ -20,13 +20,13 @@ describe TeachersPet::Actions::Base do
     end
 
     it "waits for a password if the password flag is passed without any arguments" do
-      action = TeachersPet::Actions::Base.new(password: '')
+      action = TeachersPet::Actions::Base.new(password: 'password')
       STDIN.stub(:gets).and_return('abc123')
       expect(action.octokit_config[:password]).to eq('abc123')
     end
 
     it "waits for a token if the token flag is passed without any arguments" do
-      action = TeachersPet::Actions::Base.new(token: '')
+      action = TeachersPet::Actions::Base.new(token: 'token')
       STDIN.stub(:gets).and_return('abc123')
       expect(action.octokit_config[:access_token]).to eq('abc123')
     end


### PR DESCRIPTION
Closes #60

Looking for feedback, and advice on the best way to test manually entering a prompt.

I had a lot of build issues trying to use [ruby-password](http://www.caliban.org/ruby/ruby-password.shtml)

So I extracted out what was actually needed, and added it to the gem.

You can find a GitHub mirror of the source code [here](https://github.com/savonix/ruby-password/blob/master/lib/password.rb)
