### PR TITLE
fix clone_repos and web endpoint

### DIFF
--- a/lib/teachers_pet/actions/base.rb
+++ b/lib/teachers_pet/actions/base.rb
@@ -90,6 +90,10 @@ module TeachersPet
         puts "Loading members to add:"
         read_file(file).keys
       end
+
+      def execute(command)
+        return system(command)
+      end
     end
   end
 end

--- a/lib/teachers_pet/actions/clone_repos.rb
+++ b/lib/teachers_pet/actions/clone_repos.rb
@@ -47,7 +47,7 @@ module TeachersPet
             command = "git clone #{web}#{@organization}/#{repo_name}.git"
           end
           puts " --> Cloning: '#{command}'"
-          system(command)
+          self.execute(command)
         end
       end
 

--- a/spec/commands/add_collaborators_spec.rb
+++ b/spec/commands/add_collaborators_spec.rb
@@ -24,7 +24,7 @@ describe 'add_collaborators' do
         'password' => 'abc123',
         'repository' => 'testorg/testrepo',
         'username' => ENV['USER'],
-        'web' => 'https://www.github.com/'
+        'web' => 'https://github.com/'
       )
 
       teachers_pet(:add_collaborators,

--- a/spec/commands/clone_repos_spec.rb
+++ b/spec/commands/clone_repos_spec.rb
@@ -13,7 +13,7 @@ describe 'clone_repos' do
     request_stubs << stub_get_json('https://testteacher:abc123@api.github.com/orgs/testorg/teams?per_page=100', student_teams)
     student_usernames.each do |username|
       request_stubs << stub_get_json("https://testteacher:abc123@api.github.com/repos/testorg/#{username}-testrepo", {})
-      expect_any_instance_of(TeachersPet::Actions::CloneRepos).to receive(:execute).with("git clone https://www.github.com/testorg/#{username}-testrepo.git").once
+      expect_any_instance_of(TeachersPet::Actions::CloneRepos).to receive(:execute).with("git clone https://github.com/testorg/#{username}-testrepo.git").once
     end
 
     teachers_pet(:clone_repos,

--- a/spec/commands/forks_spec.rb
+++ b/spec/commands/forks_spec.rb
@@ -23,7 +23,7 @@ describe 'forks' do
         'password' => 'abc123',
         'repository' => 'testorg/testrepo',
         'username' => ENV['USER'],
-        'web' => 'https://www.github.com/'
+        'web' => 'https://github.com/'
       )
       teachers_pet(:forks, repository: 'testorg/testrepo', password: 'abc123')
     end


### PR DESCRIPTION
clone_repos calls `self.execute(command)`, but this method does not exist.

See a half fix: https://github.com/iit-cs579/teachers_pet/commit/71af808b530ca693efdf6a56694c0300a83f2a00

However, this still does not fix the problem, as I get:

```
Cloning assignment repositories for students...
 --> Cloning: 'git clone https://www.github.com/iit-cs579/ayacha-asg.git'
Cloning into 'ayacha-asg'...
Username for 'https://www.github.com':
```

It appears that the endpoint is wrong (https://www.github.com should be https://github.com ). See the fix: https://github.com/iit-cs579/teachers_pet/commit/8a5137414fcff0f7448f6c3f658fb49e9f89760a

Thanks for a great library -- it's much better than the glue and duct tape I used last semester!
