### PR TITLE
Use to_json instead of hand written JSON strings for specs, and fix Webmock error.

### DIFF
--- a/lib/teachers_pet/actions/create_student_teams.rb
+++ b/lib/teachers_pet/actions/create_student_teams.rb
@@ -21,7 +21,8 @@ module TeachersPet
           if team
             puts "Team @#{org_login}/#{team_name} already exists."
           else
-            team = self.client.create_team(org_login, team_name)
+            team = JSON.parse(self.client.create_team(org_login, team_name))
+            team.symbolize_keys!
           end
           self.client.add_users_to_team(org_login, team, usernames)
         end

--- a/spec/commands/create_repos_spec.rb
+++ b/spec/commands/create_repos_spec.rb
@@ -26,7 +26,15 @@ describe 'create_repos' do
         end
       end
       stub_request(:post, "https://testteacher:abc123@api.github.com/orgs/testorg/repos").
-        with(body: "{\"description\":\"testrepo created for #{username}\",\"private\":#{!create_as_public},\"has_issues\":true,\"has_wiki\":false,\"has_downloads\":false,\"team_id\":#{team_id},\"name\":\"#{username}-testrepo\"}")
+        with(body: {
+          description: "testrepo created for #{username}",
+          private: !create_as_public,
+          has_issues: true,
+          has_wiki: false,
+          has_downloads: false,
+          team_id: team_id,
+          name: "#{username}-testrepo"
+        }.to_json)
     end
 
     teachers_pet(:create_repos,

--- a/spec/commands/create_student_teams_spec.rb
+++ b/spec/commands/create_student_teams_spec.rb
@@ -25,7 +25,7 @@ describe 'create_student_teams' do
          }.to_json).to_return(body: {
             id: i,
             name: student
-         })
+         }.to_json)
 
       # Checks for existing team members
       # TODO No need to retrieve members for a new team
@@ -62,7 +62,7 @@ describe 'create_student_teams' do
        }.to_json).to_return(body: {
           id: 1,
           name: 'studentteam1'
-       })
+       }.to_json)
 
     # Checks for existing team members
     # TODO No need to retrieve members for a new team

--- a/spec/commands/open_issue_spec.rb
+++ b/spec/commands/open_issue_spec.rb
@@ -26,10 +26,14 @@ describe 'open_issue' do
             team_id = st[:id]
           end
         end
-        issue_body = File.read(issue_fixture_path).gsub("\n", "\\n")
-        labels_list = labels.split(",").map(&:strip).to_s.delete(' ')
+        issue_body = File.read(issue_fixture_path)
+        labels_list = labels.split(",").map(&:strip)
         request_stubs << stub_request(:post, "https://testteacher:abc123@api.github.com/repos/testorg/#{username}-testrepo/issues").
-          with(body: "{\"labels\":#{labels_list},\"title\":\"#{issue_title}\",\"body\":\"#{issue_body}\"}").
+          with(body: {
+            labels: labels_list,
+            title: issue_title,
+            body: issue_body
+          }.to_json).
           to_return(status: 201)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ SimpleCov.start do
   add_group 'Specs', '/spec/'
 end
 
+require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/kernel/reporting'
 require 'csv'
 require 'json'


### PR DESCRIPTION
This PR addresses two issues.
- Webmock was updated and validates the response body. A Hash is not listed valid parameter (see bblimke/webmock#427)
- Handwriting json objects as strings is pretty cumbersome and not very readable. Let `to_json` do the work for us, so that we can just make a hash

This was partially extracted from education/teachers_pet#95
