### PR TITLE
travis auto testing and delete repository command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
+gem 'travis', '1.7.1'
 
 gemspec

--- a/lib/teachers_pet/actions/create_repos.rb
+++ b/lib/teachers_pet/actions/create_repos.rb
@@ -51,27 +51,18 @@ module TeachersPet
             team_id: org_teams[student][:id]
           )
 
-		  # Travis stuff:
-		  #  authenticate
-		  #github = Travis::Tools::Github.new(auto_token: true, auto_password: true) do |g|
-          #  g.ask_login    = -> { print("GitHub login:"); STDIN.gets }
-          #  g.ask_password = -> { print("Password:"); STDIN.gets }
-          #  g.ask_otp      = -> { print("Two-factor token:"); STDIN.gets }
-          #end
-
-          #github.with_token do |token|
-          #  Travis::Pro.github_auth(token)
-          #end
+          # Travis stuff:
+          #  authenticate
           travis_client = Travis::Client.new(uri: Travis::Client::PRO_URI)
           travis_client.github_auth(self.options[:token])
-		  # Make sure Travis knows about the new repo
-		  #  Need to sleep a bit, else Travis can't find the new repo
-		  travis_client.user.sync
-		  sleep 5
+          # Make sure Travis knows about the new repo
+          #  Need to sleep a bit, else Travis can't find the new repo
+          travis_client.user.sync
+          sleep 5
 
-		  # Enable Travis-CI for the repository
-		  travis_repo = travis_client.repo("#{@organization}/#{repo_name}")
-		  travis_repo.enable
+          # Enable Travis-CI for the repository
+          travis_repo = travis_client.repo("#{@organization}/#{repo_name}")
+          travis_repo.enable
           puts " --> Activated Travis for #{travis_repo.slug}"
         end
       end

--- a/lib/teachers_pet/actions/create_repos.rb
+++ b/lib/teachers_pet/actions/create_repos.rb
@@ -53,25 +53,24 @@ module TeachersPet
 
 		  # Travis stuff:
 		  #  authenticate
-		  github = Travis::Tools::Github.new(auto_token: true, auto_password: true) do |g|
-            g.ask_login    = -> { print("GitHub login:"); STDIN.gets }
-            g.ask_password = -> { print("Password:"); STDIN.gets }
-            g.ask_otp      = -> { print("Two-factor token:"); STDIN.gets }
-          end
+		  #github = Travis::Tools::Github.new(auto_token: true, auto_password: true) do |g|
+          #  g.ask_login    = -> { print("GitHub login:"); STDIN.gets }
+          #  g.ask_password = -> { print("Password:"); STDIN.gets }
+          #  g.ask_otp      = -> { print("Two-factor token:"); STDIN.gets }
+          #end
 
-          github.with_token do |token|
-            Travis::Pro.github_auth(token)
-          end
-
+          #github.with_token do |token|
+          #  Travis::Pro.github_auth(token)
+          #end
+          travis_client = Travis::Client.new(uri: Travis::Client::PRO_URI)
+          travis_client.github_auth(self.options[:token])
 		  # Make sure Travis knows about the new repo
 		  #  Need to sleep a bit, else Travis can't find the new repo
-		  Travis::Pro::User.current.sync
+		  travis_client.user.sync
 		  sleep 5
 
-		  full_repo = "#{@organization}/#{repo_name}"
-		  travis_repo = Travis::Pro::Repository.find("#{full_repo}")
-		  travis_repo.reload
 		  # Enable Travis-CI for the repository
+		  travis_repo = travis_client.repo("#{@organization}/#{repo_name}")
 		  travis_repo.enable
           puts " --> Activated Travis for #{travis_repo.slug}"
         end

--- a/lib/teachers_pet/actions/delete_repos.rb
+++ b/lib/teachers_pet/actions/delete_repos.rb
@@ -1,0 +1,55 @@
+module TeachersPet
+  module Actions
+    class DeleteRepos < Base
+      def read_info
+        @repository = self.options[:repository]
+        @organization = self.options[:organization]
+      end
+
+      def load_files
+        @students = self.read_students_file
+      end
+
+      def delete
+        # create a repo for each student
+        self.init_client
+
+        org_hash = self.client.organization(@organization)
+        abort('Organization could not be found') if org_hash.nil?
+        puts "Found organization at: #{org_hash[:login]}"
+
+        # Load the teams - there should be one team per student.
+        # Repositories are given permissions by teams
+        org_teams = self.client.get_teams_by_name(@organization)
+        # For each student - create a repository, and give permissions to their "team"
+        # The repository name is teamName-repository
+        puts "\nDeleting students' assignment repositories..."
+        @students.keys.sort.each do |student|
+          unless org_teams.key?(student)
+            puts("  ** ERROR ** - no team for #{student}")
+            next
+          end
+          repo_name = "#{student}-#{@repository}"
+
+          unless self.client.repository?(@organization, repo_name)
+            puts " --> Does not exist, skipping '#{repo_name}'"
+            next
+          end
+
+		  ######################
+		  # Only managed to get this working only with a 
+		  # Personal access token with a 'delete_repo' scope
+		  ######################
+          puts " --> Deleting '#{repo_name}'"
+          self.client.delete_repository("#{@organization}/#{repo_name}")
+        end
+      end
+
+      def run
+        self.read_info
+        self.load_files
+        self.delete
+      end
+    end
+  end
+end

--- a/lib/teachers_pet/actions/delete_repos.rb
+++ b/lib/teachers_pet/actions/delete_repos.rb
@@ -36,10 +36,10 @@ module TeachersPet
             next
           end
 
-		  ######################
-		  # Only managed to get this working only with a 
-		  # Personal access token with a 'delete_repo' scope
-		  ######################
+          ######################
+          # Only managed to get this working only with a 
+          # Personal access token with a 'delete_repo' scope
+          ######################
           puts " --> Deleting '#{repo_name}'"
           self.client.delete_repository("#{@organization}/#{repo_name}")
         end

--- a/lib/teachers_pet/actions/push_files.rb
+++ b/lib/teachers_pet/actions/push_files.rb
@@ -48,7 +48,7 @@ module TeachersPet
         my_match = nil
         if File.file?('README.md')
           File.open("README.md") do |file|
-            file.lines.each do |line|
+            file.each_line do |line|
               unless my_match
                 my_match ||= /#{@organization}\/(.*)\.svg\?token=/.match(line)
                 if my_match
@@ -69,7 +69,7 @@ module TeachersPet
           if my_match
             temp_file = Tempfile.new('foo')
             File.open("README.md") do |file|
-              file.lines.each do |line|
+              file.each_line do |line|
                 line.gsub!(/#{@organization}\/#{my_match[1]}/,"#{@organization}\/#{repo_name}")
                 temp_file.puts line
               end

--- a/lib/teachers_pet/commands/delete_repos.rb
+++ b/lib/teachers_pet/commands/delete_repos.rb
@@ -1,0 +1,14 @@
+module TeachersPet
+  class Cli
+    option :organization, required: true
+    option :repository, required: true
+
+    students_option
+    common_options
+
+    desc 'delete_repos', "Delete students' assignment repositories."
+    def delete_repos
+      TeachersPet::Actions::DeleteRepos.new(options).run
+    end
+  end
+end


### PR DESCRIPTION
This pull request is related to my comment on issue: education/teachers#3 about using travis for auto testing of students' private repos and on education/teachers#28 about managing a course with limited number of private repos by deleting and re-using repos.
Since I need both these capabilities for a course I am about to run, I went ahead and worked on them.
I have to warn you though that I don't know Ruby, thus the code is of poor style. 
If these features are useful, hopefully someone more proficient on Ruby can modify the code.
Changes:
- In create_repos command, I added a few lines which enable the repository on Travis
- In push_files, I added code that looks for a Travis badge in a README.md file and replaces the repo name in the URL, so that it matches the student's repo name.
- Added a delete_repos command (and action) to delete all repos of a piece of coursework.

