### PR TITLE
Lock activesupport to ~> 4.1.9

### DIFF
--- a/teachers_pet.gemspec
+++ b/teachers_pet.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'activesupport', '~> 4.0'
+  s.add_dependency 'activesupport', '~> 4.1.9'
   # for team membership API
   # https://developer.github.com/changes/2014-08-05-team-memberships-api/
   s.add_dependency 'octokit', '~> 3.3.0'


### PR DESCRIPTION
Currently on a fresh install of the gem for development `gem 'activesupport', '~> 4.2.0'` is being used.

According to https://github.com/rails/rails/pull/13392 `capture` in `activesupport` is being depreciated due to it not being thread safe, and there are three tests that are currently failing because of it.

This is the output
```ruby
Failures:
  1) add_collaborators through CLI prints the users on a dry run
     Failure/Error: output = capture(:stdout) do
     NoMethodError:
       undefined method `close' for nil:NilClass
     # /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/activesupport-4.2.0/lib/active_support/core_ext/kernel/reporting.rb:103:in `ensure in capture'
     # /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/activesupport-4.2.0/lib/active_support/core_ext/kernel/reporting.rb:105:in `capture'
     # ./spec/commands/add_collaborators_spec.rb:71:in `block (3 levels) in <top (required)>'
  2) TeachersPet::Cli throws an error for unsupported options
     Failure/Error: output = capture(:stderr) {
     NoMethodError:
       undefined method `close' for nil:NilClass
     # /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/activesupport-4.2.0/lib/active_support/core_ext/kernel/reporting.rb:103:in `ensure in capture'
     # /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/activesupport-4.2.0/lib/active_support/core_ext/kernel/reporting.rb:105:in `capture'
     # ./spec/cli_spec.rb:12:in `block (2 levels) in <top (required)>'
  3) TeachersPet::Cli shows the help output
     Failure/Error: stdout = capture(:stdout) {
     NoMethodError:
       undefined method `close' for nil:NilClass
     # /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/activesupport-4.2.0/lib/active_support/core_ext/kernel/reporting.rb:103:in `ensure in capture'
     # /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/activesupport-4.2.0/lib/active_support/core_ext/kernel/reporting.rb:105:in `capture'
     # ./spec/cli_spec.rb:20:in `block (2 levels) in <top (required)>'
Finished in 1.39 seconds (files took 0.73582 seconds to load)
31 examples, 3 failures, 2 pending
Failed examples:
rspec ./spec/commands/add_collaborators_spec.rb:70 # add_collaborators through CLI prints the users on a dry run
rspec ./spec/cli_spec.rb:8 # TeachersPet::Cli throws an error for unsupported options
rspec ./spec/cli_spec.rb:18 # TeachersPet::Cli shows the help output
```

I'm also open to suggestions on how to change these methods so that we don't have to use capture in the future.

Thanks!