### PR TITLE
Use RSpec output matcher instead of output from activesupport

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -9,20 +9,15 @@ describe TeachersPet::Cli do
     # Make sure it short-circuits
     expect(TeachersPet::Actions::CreateStudentTeams).to_not receive(:new)
 
-    output = capture(:stderr) {
+    expect {
       TeachersPet::Cli.start(%w(create_student_teams --organization testorg --unsupported-option))
-    }
-    expect(output).to include('--unsupported-option')
+    }.to output(/--unsupported-option/).to_stderr
+
   end
 
   it "shows the help output" do
-    stderr = nil
-    stdout = capture(:stdout) {
-      stderr = capture(:stderr) {
-        TeachersPet::Cli.start(%w(help))
-      }
-    }
-    expect(stderr).to eq('')
-    expect(stdout).to include('create_student_teams')
+    expect {
+      TeachersPet::Cli.start(%w(help))
+    }.to output(/create_student_teams/).to_stdout
   end
 end

--- a/spec/commands/add_collaborators_spec.rb
+++ b/spec/commands/add_collaborators_spec.rb
@@ -68,17 +68,15 @@ describe 'add_collaborators' do
     end
 
     it "prints the users on a dry run" do
-      output = capture(:stdout) do
+      expect {
         teachers_pet(:add_collaborators,
-          repository: 'testorg/testrepo',
-          members: students_list_fixture_path,
-          username: 'testteacher',
-          password: 'abc123',
-          dry_run: true
-        )
-      end
-
-      expect(output).to include('teststudent1')
+                     repository: 'testorg/testrepo',
+                     members: students_list_fixture_path,
+                     username: 'testteacher',
+                     password: 'abc123',
+                     dry_run: true
+                    )
+      }.to output(/teststudent1/).to_stdout
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ SimpleCov.start do
 end
 
 require 'active_support/core_ext/hash/keys'
-require 'active_support/core_ext/kernel/reporting'
 require 'csv'
 require 'json'
 require 'webmock/rspec'


### PR DESCRIPTION
From #103.

Thanks @afeld for the pointer! I didn't know RSpec could do that.