### PR TITLE
delete-repos command

### DIFF
--- a/lib/teachers_pet/actions/delete_repos.rb
+++ b/lib/teachers_pet/actions/delete_repos.rb
@@ -1,0 +1,55 @@
+module TeachersPet
+  module Actions
+    class DeleteRepos < Base
+      def read_info
+        @repository = self.options[:repository]
+        @organization = self.options[:organization]
+      end
+
+      def load_files
+        @students = self.read_students_file
+      end
+
+      def delete
+        # create a repo for each student
+        self.init_client
+
+        org_hash = self.client.organization(@organization)
+        abort('Organization could not be found') if org_hash.nil?
+        puts "Found organization at: #{org_hash[:login]}"
+
+        # Load the teams - there should be one team per student.
+        # Repositories are given permissions by teams
+        org_teams = self.client.get_teams_by_name(@organization)
+        # For each student - create a repository, and give permissions to their "team"
+        # The repository name is teamName-repository
+        puts "\nDeleting students' assignment repositories..."
+        @students.keys.sort.each do |student|
+          unless org_teams.key?(student)
+            puts("  ** ERROR ** - no team for #{student}")
+            next
+          end
+          repo_name = "#{student}-#{@repository}"
+
+          unless self.client.repository?(@organization, repo_name)
+            puts " --> Does not exist, skipping '#{repo_name}'"
+            next
+          end
+
+		  ######################
+		  # Only managed to get this working only with a 
+		  # Personal access token with a 'delete_repo' scope
+		  ######################
+          puts " --> Deleting '#{repo_name}'"
+          self.client.delete_repository("#{@organization}/#{repo_name}")
+        end
+      end
+
+      def run
+        self.read_info
+        self.load_files
+        self.delete
+      end
+    end
+  end
+end

--- a/lib/teachers_pet/commands/delete_repos.rb
+++ b/lib/teachers_pet/commands/delete_repos.rb
@@ -1,0 +1,14 @@
+module TeachersPet
+  class Cli
+    option :organization, required: true
+    option :repository, required: true
+
+    students_option
+    common_options
+
+    desc 'delete_repos', "Delete students' assignment repositories."
+    def delete_repos
+      TeachersPet::Actions::DeleteRepos.new(options).run
+    end
+  end
+end


### PR DESCRIPTION
It should help with managing a course with limited number of private repos by deleting and re-using repos, as discussed in education/teachers#28.
It follows closely the create_repos action but deletes instead of creating. (could share code somehow)

I could not get this to work with username/password authentication. It only worked after creating a personal access token with a 'delete_repo' scope and using that token to login to Github.

