### PR TITLE
add a command to output the gem version number

### DIFF
--- a/lib/teachers_pet/commands/version.rb
+++ b/lib/teachers_pet/commands/version.rb
@@ -1,0 +1,8 @@
+module TeachersPet
+  class Cli
+    desc "version", "Print out the gem version number."
+    def version
+      puts TeachersPet::VERSION
+    end
+  end
+end

--- a/spec/commands/version_spec.rb
+++ b/spec/commands/version_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'version' do
+  include CommandHelpers
+
+  it "prints the version number" do
+    expect {
+      teachers_pet(:version)
+    }.to output("#{TeachersPet::VERSION}\n").to_stdout
+  end
+end


### PR DESCRIPTION
Idea came from troubleshooting https://github.com/education/teachers_pet/issues/110.