### PR TITLE
Delete repos cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ When grading, use the `clone_repos` command to clone all the repositories in the
 
 When running a GitHub workshop, it's nice to be able to merge a bunch of pull requests on a particular repository all at once. `merge_pull_requests` will handle this for you.
 
+### Delete specified repositories
+
+You can delete the specified repositories via `delete_repos`, it'll be useful once you pushed something wrong, or you may when to recycle the quota of private repo. Be careful with this command, the delete process can not be reverted, you can backup the repositories locally in case.
+
 ## Related projects
 
 * https://education.github.com/guide

--- a/lib/teachers_pet/actions/delete_repos.rb
+++ b/lib/teachers_pet/actions/delete_repos.rb
@@ -1,0 +1,42 @@
+module TeachersPet
+  module Actions
+    class DeleteRepos < Base
+      def read_info
+        @repository = self.options[:repository]
+        @organization = self.options[:organization]
+      end
+
+      def load_files
+        @students = self.read_students_file
+      end
+
+      def delete
+        # delete specified repo of each student
+        self.init_client
+        org_hash = self.client.organization(@organization)
+        abort('Organization could not be found') if org_hash.nil?
+        puts "Found organization at: #{org_hash[:login]}"
+        puts "\nDeleting specified repositories of students..."
+        @students.keys.sort.each do |student|
+          repo_name = "#{student}-#{@repository}"
+          if self.client.repository?(@organization, repo_name)
+            puts " --> Deleting '#{repo_name}'"
+            if self.client.delete_repository(@organization + '/' + repo_name)
+              puts "#{repo_name} deleted successfully"
+            else
+              puts "Failed, please make sure you have permission on this repo"
+            end
+          else
+            puts " --> Repository '#{student}-#{@repository}' not found"
+          end
+        end
+      end
+
+      def run
+        self.read_info
+        self.load_files
+        self.delete
+      end
+    end
+  end
+end

--- a/lib/teachers_pet/commands/delete_repos.rb
+++ b/lib/teachers_pet/commands/delete_repos.rb
@@ -1,0 +1,14 @@
+module TeachersPet
+  class Cli
+    option :organization, required: true
+    option :repository, required: true
+
+    students_option
+    common_options
+
+    desc 'delete_repos', "Delete specified repositories of students."
+    def delete_repos
+      TeachersPet::Actions::DeleteRepos.new(options).run
+    end
+  end
+end

--- a/spec/commands/delete_repos_spec.rb
+++ b/spec/commands/delete_repos_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe 'delete_repos' do
+  include CommandHelpers
+
+  def common_test(create_as_public)
+    request_stubs = []
+
+    request_stubs << stub_get_json('https://testteacher:abc123@api.github.com/orgs/testorg',
+      login: 'testorg',
+      url: 'https://api.github.com/orgs/testorg'
+    )
+    request_stubs << stub_get_json('https://testteacher:abc123@api.github.com/orgs/testorg/teams?per_page=100', student_teams)
+    student_usernames.each do |username|
+      # Check for the repos existing already
+      stub_request(:get, "https://testteacher:abc123@api.github.com/repos/testorg/#{username}-testrepo").
+        to_return(status: 404)
+    end
+
+    student_usernames.each do |username|
+      # create the repo for test
+      team_id = 0
+      student_teams.each do |st|
+        if st[:name].eql?(username)
+          team_id = st[:id]
+        end
+      end
+      stub_request(:post, "https://testteacher:abc123@api.github.com/orgs/testorg/repos").
+        with(body: {
+          description: "testrepo created for #{username}",
+          private: !create_as_public,
+          has_issues: true,
+          has_wiki: false,
+          has_downloads: false,
+          team_id: team_id,
+          name: "#{username}-testrepo"
+        }.to_json)
+    end
+
+    teachers_pet(:create_repos,
+      repository: 'testrepo',
+      organization: 'testorg',
+      public: create_as_public,
+
+      students: students_list_fixture_path,
+
+      username: 'testteacher',
+      password: 'abc123'
+    )
+    teachers_pet(:delete_repos,
+      repository: 'testrepo',
+      organization: 'testorg',
+
+      students: students_list_fixture_path,
+
+      username: 'testteacher',
+      password: 'abc123'
+    )
+
+    request_stubs.each do |request_stub|
+      expect(request_stub).to have_been_requested.at_least_once
+    end
+  end
+
+  it "create repos public" do
+    common_test(true)
+  end
+
+  it "create repos private" do
+    common_test(false)
+  end
+end

--- a/spec/commands/delete_repos_spec.rb
+++ b/spec/commands/delete_repos_spec.rb
@@ -2,21 +2,14 @@ require 'spec_helper'
 
 describe 'delete_repos' do
   include CommandHelpers
+  include_context "with expected requests"
 
-  def common_test(create_as_public)
-    request_stubs = []
-
-    request_stubs << stub_get_json('https://testteacher:abc123@api.github.com/orgs/testorg',
-      login: 'testorg',
-      url: 'https://api.github.com/orgs/testorg'
-    )
-    request_stubs << stub_get_json('https://testteacher:abc123@api.github.com/orgs/testorg/teams?per_page=100', student_teams)
+  def stub_student_create_repo_requests(create_as_public)
     student_usernames.each do |username|
       # Check for the repos existing already
       stub_request(:get, "https://testteacher:abc123@api.github.com/repos/testorg/#{username}-testrepo").
         to_return(status: 404)
     end
-
     student_usernames.each do |username|
       # create the repo for test
       team_id = 0
@@ -36,37 +29,56 @@ describe 'delete_repos' do
           name: "#{username}-testrepo"
         }.to_json)
     end
+  end
 
+  def teachers_pet_create_repos!(create_as_public)
     teachers_pet(:create_repos,
       repository: 'testrepo',
       organization: 'testorg',
       public: create_as_public,
-
       students: students_list_fixture_path,
-
       username: 'testteacher',
       password: 'abc123'
     )
+  end
+
+  def stub_get_org_request
+    stub_get_json('https://testteacher:abc123@api.github.com/orgs/testorg',
+      login: 'testorg',
+      url: 'https://api.github.com/orgs/testorg'
+    )
+  end
+
+  def stub_get_org_teams_request
+    stub_get_json('https://testteacher:abc123@api.github.com/orgs/testorg/teams?per_page=100', student_teams)
+  end
+
+  before(:each) do
+    @expected_requests << stub_get_org_request
+    @expected_requests << stub_get_org_teams_request
+  end
+
+  it "deletes public repos" do
+    stub_student_create_repo_requests(true)
+    teachers_pet_create_repos!(true)
     teachers_pet(:delete_repos,
       repository: 'testrepo',
       organization: 'testorg',
-
       students: students_list_fixture_path,
-
       username: 'testteacher',
       password: 'abc123'
     )
-
-    request_stubs.each do |request_stub|
-      expect(request_stub).to have_been_requested.at_least_once
-    end
   end
 
-  it "create repos public" do
-    common_test(true)
-  end
-
-  it "create repos private" do
-    common_test(false)
+  it "deletes private repos" do
+    stub_student_create_repo_requests(false)
+    teachers_pet_create_repos!(false)
+    teachers_pet(:delete_repos,
+      repository: 'testrepo',
+      organization: 'testorg',
+      students: students_list_fixture_path,
+      username: 'testteacher',
+      password: 'abc123'
+    )
   end
 end

--- a/spec/support/shared_context_with_expected_requests.rb
+++ b/spec/support/shared_context_with_expected_requests.rb
@@ -1,0 +1,11 @@
+shared_context "with expected requests" do
+  before(:each) do
+    @expected_requests = []
+  end
+
+  after(:each) do
+    @expected_requests.each do |request_stub|
+      expect(request_stub).to have_been_requested.at_least_once
+    end
+  end
+end


### PR DESCRIPTION
@PeterDaveHello - Thanks for your contribution. I'm using this work as an opportunity to clean up how we are doing testing in this app. I see that you basically copied the format from the create_repos spec - which was a good move.

After reworking this so I can understand what is happening in https://github.com/education/teachers_pet/commit/be8a8b1ddb3a8ef79a88f53f6bd05649417f0515, I notice that we are not stubbing any repo deletion requests - which then therefore would mean that these tests aren't actually sending any API requests.

@PeterDaveHello - these tests should be hitting the a delete repo endpoint on the GitHub API, should they not? Can we rework them so that they do? These tests should fail in the case the we comment out the `teachers_pet(:delete_repos)`... block.

/cc @johndbritton 