### PR TITLE
Added possibility to add a personalized issue's body

### DIFF
--- a/lib/teachers_pet/actions/open_issue.rb
+++ b/lib/teachers_pet/actions/open_issue.rb
@@ -12,11 +12,15 @@ module TeachersPet
           }
         }
         @issue_file = self.options[:body]
+        @path_to_file = self.options[:path]
+
       end
 
       def load_files
         @students = self.read_students_file
-        @issue[:body] = File.open(@issue_file).read
+        if !@issue_file.nil?
+          @issue[:body] = File.open(@issue_file).read
+        end
       end
 
       def create
@@ -42,6 +46,9 @@ module TeachersPet
             next
           end
 
+          if @issue_file.nil?
+            @issue[:body] = File.open(@path_to_file + student+".md").read
+          end
           # Create the issue with octokit
           self.client.create_issue("#{@organization}/#{repo_name}", @issue[:title], @issue[:body], @issue[:options])
         end

--- a/lib/teachers_pet/commands/open_issue.rb
+++ b/lib/teachers_pet/commands/open_issue.rb
@@ -6,6 +6,7 @@ module TeachersPet
     option :title, desc: "The title of the issue to be created"
     option :body, banner: 'PATH', desc: "The path to the file containing the issue body (.txt or .md)"
     option :labels, banner: 'LABEL1,LABEL2'
+    option :path, desc: 'Relative path to the folder containing the issue body (student.md)'
 
     students_option
     common_options


### PR DESCRIPTION
In some cases I wanted to give a specific readme.md per student, for
example, to give feedback.
This allows the possibility to do that, you only have to have a file
named as student_github_user.md